### PR TITLE
Crash on block #13225593. Event: /ibc.applications.interchain_accounts.controller.v1.MsgRegisterInterchainAccount 

### DIFF
--- a/juno-migration/13225593/.project_juno-cid
+++ b/juno-migration/13225593/.project_juno-cid
@@ -1,0 +1,1 @@
+@DEVS_FIXME

--- a/juno-migration/13225593/project_juno.yaml
+++ b/juno-migration/13225593/project_juno.yaml
@@ -16,8 +16,8 @@ schema:
   file: ./schema.graphql
 
 parent:
-  reference: QmdMLdD6UwcCi69iCt1JRvA75ES7LGAsjrKXVYJ7YgvXxf
-  block: 8338891
+  reference: UNKNOWN_CID_YOUR_NOT_UPDATE_MAINNET
+  block: 13225593
 
 network:
   chainId: juno-1

--- a/project_juno.yaml
+++ b/project_juno.yaml
@@ -16,8 +16,8 @@ schema:
   file: ./schema.graphql
 
 parent:
-  reference: QmdMLdD6UwcCi69iCt1JRvA75ES7LGAsjrKXVYJ7YgvXxf
-  block: 8338891
+  reference: ___UNKNOWN_CID___
+  block: 13225593
 
 network:
   chainId: juno-1

--- a/proto/ibc/applications/interchain_accounts/controller/v1/controller.proto
+++ b/proto/ibc/applications/interchain_accounts/controller/v1/controller.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package ibc.applications.interchain_accounts.controller.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types";
+
+// Params defines the set of on-chain interchain accounts parameters.
+// The following parameters may be used to disable the controller submodule.
+message Params {
+  // controller_enabled enables or disables the controller submodule.
+  bool controller_enabled = 1;
+}

--- a/proto/ibc/applications/interchain_accounts/controller/v1/query.proto
+++ b/proto/ibc/applications/interchain_accounts/controller/v1/query.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package ibc.applications.interchain_accounts.controller.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types";
+
+import "ibc/applications/interchain_accounts/controller/v1/controller.proto";
+import "google/api/annotations.proto";
+
+// Query provides defines the gRPC querier service.
+service Query {
+  // InterchainAccount returns the interchain account address for a given owner address on a given connection
+  rpc InterchainAccount(QueryInterchainAccountRequest) returns (QueryInterchainAccountResponse) {
+    option (google.api.http).get =
+        "/ibc/apps/interchain_accounts/controller/v1/owners/{owner}/connections/{connection_id}";
+  }
+
+  // Params queries all parameters of the ICA controller submodule.
+  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+    option (google.api.http).get = "/ibc/apps/interchain_accounts/controller/v1/params";
+  }
+}
+
+// QueryInterchainAccountRequest is the request type for the Query/InterchainAccount RPC method.
+message QueryInterchainAccountRequest {
+  string owner         = 1;
+  string connection_id = 2;
+}
+
+// QueryInterchainAccountResponse the response type for the Query/InterchainAccount RPC method.
+message QueryInterchainAccountResponse {
+  string address = 1;
+}
+
+// QueryParamsRequest is the request type for the Query/Params RPC method.
+message QueryParamsRequest {}
+
+// QueryParamsResponse is the response type for the Query/Params RPC method.
+message QueryParamsResponse {
+  // params defines the parameters of the module.
+  Params params = 1;
+}

--- a/proto/ibc/applications/interchain_accounts/controller/v1/tx.proto
+++ b/proto/ibc/applications/interchain_accounts/controller/v1/tx.proto
@@ -1,0 +1,82 @@
+syntax = "proto3";
+
+package ibc.applications.interchain_accounts.controller.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types";
+
+import "gogoproto/gogo.proto";
+import "ibc/applications/interchain_accounts/v1/packet.proto";
+import "ibc/applications/interchain_accounts/controller/v1/controller.proto";
+import "cosmos/msg/v1/msg.proto";
+import "ibc/core/channel/v1/channel.proto";
+
+// Msg defines the 27-interchain-accounts/controller Msg service.
+service Msg {
+  option (cosmos.msg.v1.service) = true;
+
+  // RegisterInterchainAccount defines a rpc handler for MsgRegisterInterchainAccount.
+  rpc RegisterInterchainAccount(MsgRegisterInterchainAccount) returns (MsgRegisterInterchainAccountResponse);
+  // SendTx defines a rpc handler for MsgSendTx.
+  rpc SendTx(MsgSendTx) returns (MsgSendTxResponse);
+  // UpdateParams defines a rpc handler for MsgUpdateParams.
+  rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
+}
+
+// MsgRegisterInterchainAccount defines the payload for Msg/RegisterAccount
+message MsgRegisterInterchainAccount {
+  option (cosmos.msg.v1.signer) = "owner";
+
+  option (gogoproto.goproto_getters) = false;
+
+  string                    owner         = 1;
+  string                    connection_id = 2;
+  string                    version       = 3;
+  ibc.core.channel.v1.Order ordering      = 4;
+}
+
+// MsgRegisterInterchainAccountResponse defines the response for Msg/RegisterAccount
+message MsgRegisterInterchainAccountResponse {
+  option (gogoproto.goproto_getters) = false;
+
+  string channel_id = 1;
+  string port_id    = 2;
+}
+
+// MsgSendTx defines the payload for Msg/SendTx
+message MsgSendTx {
+  option (cosmos.msg.v1.signer) = "owner";
+
+  option (gogoproto.goproto_getters) = false;
+
+  string                                                              owner         = 1;
+  string                                                              connection_id = 2;
+  ibc.applications.interchain_accounts.v1.InterchainAccountPacketData packet_data   = 3 [(gogoproto.nullable) = false];
+  // Relative timeout timestamp provided will be added to the current block time during transaction execution.
+  // The timeout timestamp must be non-zero.
+  uint64 relative_timeout = 4;
+}
+
+// MsgSendTxResponse defines the response for MsgSendTx
+message MsgSendTxResponse {
+  option (gogoproto.goproto_getters) = false;
+
+  uint64 sequence = 1;
+}
+
+// MsgUpdateParams defines the payload for Msg/UpdateParams
+message MsgUpdateParams {
+  option (cosmos.msg.v1.signer) = "signer";
+
+  option (gogoproto.goproto_getters) = false;
+
+  // signer address
+  string signer = 1;
+
+  // params defines the 27-interchain-accounts/controller parameters to update.
+  //
+  // NOTE: All parameters must be supplied.
+  Params params = 2 [(gogoproto.nullable) = false];
+}
+
+// MsgUpdateParamsResponse defines the response for Msg/UpdateParams
+message MsgUpdateParamsResponse {}

--- a/proto/ibc/applications/interchain_accounts/genesis/v1/genesis.proto
+++ b/proto/ibc/applications/interchain_accounts/genesis/v1/genesis.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package ibc.applications.interchain_accounts.genesis.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/genesis/types";
+
+import "gogoproto/gogo.proto";
+import "ibc/applications/interchain_accounts/controller/v1/controller.proto";
+import "ibc/applications/interchain_accounts/host/v1/host.proto";
+
+// GenesisState defines the interchain accounts genesis state
+message GenesisState {
+  ControllerGenesisState controller_genesis_state = 1 [(gogoproto.nullable) = false];
+  HostGenesisState       host_genesis_state       = 2 [(gogoproto.nullable) = false];
+}
+
+// ControllerGenesisState defines the interchain accounts controller genesis state
+message ControllerGenesisState {
+  repeated ActiveChannel                                    active_channels     = 1 [(gogoproto.nullable) = false];
+  repeated RegisteredInterchainAccount                      interchain_accounts = 2 [(gogoproto.nullable) = false];
+  repeated string                                           ports               = 3;
+  ibc.applications.interchain_accounts.controller.v1.Params params              = 4 [(gogoproto.nullable) = false];
+}
+
+// HostGenesisState defines the interchain accounts host genesis state
+message HostGenesisState {
+  repeated ActiveChannel                              active_channels     = 1 [(gogoproto.nullable) = false];
+  repeated RegisteredInterchainAccount                interchain_accounts = 2 [(gogoproto.nullable) = false];
+  string                                              port                = 3;
+  ibc.applications.interchain_accounts.host.v1.Params params              = 4 [(gogoproto.nullable) = false];
+}
+
+// ActiveChannel contains a connection ID, port ID and associated active channel ID, as well as a boolean flag to
+// indicate if the channel is middleware enabled
+message ActiveChannel {
+  string connection_id         = 1;
+  string port_id               = 2;
+  string channel_id            = 3;
+  bool   is_middleware_enabled = 4;
+}
+
+// RegisteredInterchainAccount contains a connection ID, port ID and associated interchain account address
+message RegisteredInterchainAccount {
+  string connection_id   = 1;
+  string port_id         = 2;
+  string account_address = 3;
+}

--- a/proto/ibc/applications/interchain_accounts/host/v1/host.proto
+++ b/proto/ibc/applications/interchain_accounts/host/v1/host.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package ibc.applications.interchain_accounts.host.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types";
+
+// Params defines the set of on-chain interchain accounts parameters.
+// The following parameters may be used to disable the host submodule.
+message Params {
+  // host_enabled enables or disables the host submodule.
+  bool host_enabled = 1;
+  // allow_messages defines a list of sdk message typeURLs allowed to be executed on a host chain.
+  repeated string allow_messages = 2;
+}

--- a/proto/ibc/applications/interchain_accounts/host/v1/query.proto
+++ b/proto/ibc/applications/interchain_accounts/host/v1/query.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package ibc.applications.interchain_accounts.host.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types";
+
+import "google/api/annotations.proto";
+import "ibc/applications/interchain_accounts/host/v1/host.proto";
+
+// Query provides defines the gRPC querier service.
+service Query {
+  // Params queries all parameters of the ICA host submodule.
+  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+    option (google.api.http).get = "/ibc/apps/interchain_accounts/host/v1/params";
+  }
+}
+
+// QueryParamsRequest is the request type for the Query/Params RPC method.
+message QueryParamsRequest {}
+
+// QueryParamsResponse is the response type for the Query/Params RPC method.
+message QueryParamsResponse {
+  // params defines the parameters of the module.
+  Params params = 1;
+}

--- a/proto/ibc/applications/interchain_accounts/host/v1/tx.proto
+++ b/proto/ibc/applications/interchain_accounts/host/v1/tx.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package ibc.applications.interchain_accounts.host.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types";
+
+import "gogoproto/gogo.proto";
+import "cosmos/msg/v1/msg.proto";
+import "ibc/applications/interchain_accounts/host/v1/host.proto";
+
+// Msg defines the 27-interchain-accounts/host Msg service.
+service Msg {
+  option (cosmos.msg.v1.service) = true;
+
+  // UpdateParams defines a rpc handler for MsgUpdateParams.
+  rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
+}
+
+// MsgUpdateParams defines the payload for Msg/UpdateParams
+message MsgUpdateParams {
+  option (cosmos.msg.v1.signer) = "signer";
+
+  option (gogoproto.goproto_getters) = false;
+
+  // signer address
+  string signer = 1;
+
+  // params defines the 27-interchain-accounts/host parameters to update.
+  //
+  // NOTE: All parameters must be supplied.
+  Params params = 2 [(gogoproto.nullable) = false];
+}
+
+// MsgUpdateParamsResponse defines the response for Msg/UpdateParams
+message MsgUpdateParamsResponse {}

--- a/proto/ibc/applications/interchain_accounts/v1/account.proto
+++ b/proto/ibc/applications/interchain_accounts/v1/account.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package ibc.applications.interchain_accounts.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types";
+
+import "cosmos_proto/cosmos.proto";
+import "gogoproto/gogo.proto";
+import "cosmos/auth/v1beta1/auth.proto";
+
+// An InterchainAccount is defined as a BaseAccount & the address of the account owner on the controller chain
+message InterchainAccount {
+  option (gogoproto.goproto_getters)         = false;
+  option (gogoproto.goproto_stringer)        = false;
+  option (cosmos_proto.implements_interface) = "ibc.applications.interchain_accounts.v1.InterchainAccountI";
+
+  cosmos.auth.v1beta1.BaseAccount base_account  = 1 [(gogoproto.embed) = true];
+  string                          account_owner = 2;
+}

--- a/proto/ibc/applications/interchain_accounts/v1/metadata.proto
+++ b/proto/ibc/applications/interchain_accounts/v1/metadata.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package ibc.applications.interchain_accounts.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types";
+
+// Metadata defines a set of protocol specific data encoded into the ICS27 channel version bytestring
+// See ICS004: https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#Versioning
+message Metadata {
+  // version defines the ICS27 protocol version
+  string version = 1;
+  // controller_connection_id is the connection identifier associated with the controller chain
+  string controller_connection_id = 2;
+  // host_connection_id is the connection identifier associated with the host chain
+  string host_connection_id = 3;
+  // address defines the interchain account address to be fulfilled upon the OnChanOpenTry handshake step
+  // NOTE: the address field is empty on the OnChanOpenInit handshake step
+  string address = 4;
+  // encoding defines the supported codec format
+  string encoding = 5;
+  // tx_type defines the type of transactions the interchain account can execute
+  string tx_type = 6;
+}

--- a/proto/ibc/applications/interchain_accounts/v1/packet.proto
+++ b/proto/ibc/applications/interchain_accounts/v1/packet.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package ibc.applications.interchain_accounts.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types";
+
+import "google/protobuf/any.proto";
+import "gogoproto/gogo.proto";
+
+// Type defines a classification of message issued from a controller chain to its associated interchain accounts
+// host
+enum Type {
+  option (gogoproto.goproto_enum_prefix) = false;
+
+  // Default zero value enumeration
+  TYPE_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "UNSPECIFIED"];
+  // Execute a transaction on an interchain accounts host chain
+  TYPE_EXECUTE_TX = 1 [(gogoproto.enumvalue_customname) = "EXECUTE_TX"];
+}
+
+// InterchainAccountPacketData is comprised of a raw transaction, type of transaction and optional memo field.
+message InterchainAccountPacketData {
+  Type   type = 1;
+  bytes  data = 2;
+  string memo = 3;
+}
+
+// CosmosTx contains a list of sdk.Msg's. It should be used when sending transactions to an SDK host chain.
+message CosmosTx {
+  repeated google.protobuf.Any messages = 1;
+}


### PR DESCRIPTION
Added event: /ibc.applications.interchain_accounts.controller.v1.MsgRegisterInterchainAccount on block 13225593.

```
2024-03-14T15:18:18.599Z <api-#2> ERROR Failed to decode message Error: Unregistered type url: /ibc.applications.interchain_accounts.controller.v1.MsgRegisterInterchainAccount
2024-03-14T15:18:18.674Z <Worker Service #2-#2> ERROR Failed to index block 13225593: Error: Unregistered type url: /ibc.applications.interchain_accounts.controller.v1.MsgRegisterInterchainAccount
    at Registry.lookupTypeWithError (/usr/local/lib/node_modules/@subql/node-cosmos/node_modules/@cosmjs/proto-signing/build/registry.js:74:19)
    at Registry.decode (/usr/local/lib/node_modules/@subql/node-cosmos/node_modules/@cosmjs/proto-signing/build/registry.js:117:27)
    at CosmosClient.decodeMsg (/usr/local/lib/node_modules/@subql/node-cosmos/dist/indexer/api.service.js:151:46)
    at get decodedMsg (/usr/local/lib/node_modules/@subql/node-cosmos/dist/utils/cosmos.js:164:47)
    at get (<anonymous>)
    at VM2 Wrapper.get (/usr/local/lib/node_modules/@subql/node-cosmos/node_modules/vm2/lib/bridge.js:447:11)
    at t.handleMessage (webpack://cosmos-dictionaries/src/mappings/mappingHandlers.ts:29:61)
```